### PR TITLE
fix(bug): logger production config regression

### DIFF
--- a/logger/config.go
+++ b/logger/config.go
@@ -100,30 +100,7 @@ func (cfg *Config) BuildLogger() (*zap.Logger, error) {
 	case off, none:
 		return zap.NewNop(), nil
 	case production:
-		zCfg = zap.Config{
-			Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
-			Development: false,
-			Sampling: &zap.SamplingConfig{
-				Initial:    100,
-				Thereafter: 100,
-			},
-			EncoderConfig: zapcore.EncoderConfig{
-				TimeKey:        "ts",
-				LevelKey:       "level",
-				NameKey:        "logger",
-				CallerKey:      "caller",
-				FunctionKey:    zapcore.OmitKey,
-				MessageKey:     "msg",
-				StacktraceKey:  "stacktrace",
-				LineEnding:     zapcore.DefaultLineEnding,
-				EncodeLevel:    zapcore.LowercaseLevelEncoder,
-				EncodeTime:     zapcore.EpochTimeEncoder,
-				EncodeDuration: zapcore.SecondsDurationEncoder,
-				EncodeCaller:   zapcore.ShortCallerEncoder,
-			},
-			OutputPaths:      []string{"stderr"},
-			ErrorOutputPaths: []string{"stderr"},
-		}
+		zCfg = zap.NewProductionConfig()
 	case development:
 		zCfg = zap.Config{
 			Level:       zap.NewAtomicLevelAt(zap.DebugLevel),

--- a/logger/plugin.go
+++ b/logger/plugin.go
@@ -28,7 +28,7 @@ func (z *ZapLogger) Init(cfg config.Configurer) error {
 
 		z.base, err = z.cfg.BuildLogger()
 		if err != nil {
-			return errors.E(op, errors.Disabled, err)
+			return errors.E(op, err)
 		}
 
 		return nil
@@ -36,17 +36,17 @@ func (z *ZapLogger) Init(cfg config.Configurer) error {
 
 	err = cfg.UnmarshalKey(PluginName, &z.cfg)
 	if err != nil {
-		return errors.E(op, errors.Disabled, err)
+		return errors.E(op, err)
 	}
 
 	err = cfg.UnmarshalKey(PluginName, &z.channels)
 	if err != nil {
-		return errors.E(op, errors.Disabled, err)
+		return errors.E(op, err)
 	}
 
 	z.base, err = z.cfg.BuildLogger()
 	if err != nil {
-		return errors.E(op, errors.Disabled, err)
+		return errors.E(op, err)
 	}
 	return nil
 }


### PR DESCRIPTION
# Reason for This PR

- Logger should always show an error and never be disabled (w/o error).
- Production logger config w/o encoder name cause an error.

## Description of Changes

- Fix logger regression. Use recommended production config.
- Always return an error from the logger `Init` function for the endure.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
