### PR TITLE
Make sure that rr_header  is not rejected

### DIFF
--- a/amqp/amqpjobs/item.go
+++ b/amqp/amqpjobs/item.go
@@ -218,8 +218,8 @@ func (c *consumer) unpack(d amqp.Delivery) (*Item, error) {
 		item.Options.Pipeline = d.Headers[job.RRPipeline].(string)
 	}
 
-	if h, ok := d.Headers[job.RRHeaders].([]byte); ok {
-		err := json.Unmarshal(h, &item.Headers)
+	if h, ok := d.Headers[job.RRHeaders].(string); ok {
+		err := json.Unmarshal([]byte(h), &item.Headers)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes the problem of rr_header being ignored regardless of its content, as it never is a byte array.

# Reason for This PR

When I publish a message via amqp it is correctly consumed by roadrunner, but the headers are always empty when I try to access them in PHP with `HeadersTrait#getHeaders()`  

I was using an external message producer to test this behaviour. After applying the changes (and formatting the rr_header JSON properly) I was able to get the headers

## Description of Changes

The execution never went past through the `[]byte` type assertion.
I have changes the type assertion to `string` and then converted the string to byte array required by `json.Unmarshall`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
