### PR TITLE
fix(static, http): set headers right before the serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ All old and new http metrics will be available after the middleware is activated
 ## 🩹 Fixes:
 
 - 🐛 Fix: GRPC server will show message when started.
+- 🐛 Fix: Static plugin headers were added to all requests. [BUG](https://github.com/spiral/roadrunner-plugins/issues/115)
 
 ## v2.5.2 (27.10.2021)
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
-    'Linux / Build (Go 1.17.1, PHP 7.4, OS ubuntu-latest)',
-    'Linux / Build (Go 1.17.1, PHP 8.0, OS ubuntu-latest)',
-    'Linux / Build (Go 1.17.1, PHP 8.1, OS ubuntu-latest)',
+    'Linux / Build (Go 1.17.3, PHP 7.4, OS ubuntu-latest)',
+    'Linux / Build (Go 1.17.3, PHP 8.0, OS ubuntu-latest)',
+    'Linux / Build (Go 1.17.3, PHP 8.1, OS ubuntu-latest)',
     'Linters / Golang-CI (lint) ',
 ]
 required_approvals = 0

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/nats-io/nats.go v1.13.0
 	github.com/newrelic/go-agent/v3 v3.15.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/rabbitmq/amqp091-go v1.1.0
+	github.com/rabbitmq/amqp091-go v1.2.0
 	github.com/spf13/viper v1.9.0
 	// spiral
 	github.com/spiral/endure v1.0.8
@@ -38,8 +38,8 @@ require (
 	github.com/yookoala/gofast v0.6.0
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/zap v1.19.1
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2
-	golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c
+	golang.org/x/net v0.0.0-20211116231205-47ca1ff31462
+	golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -99,11 +99,11 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
-	golang.org/x/crypto v0.0.0-20211115234514-b4de73f9ece8 // indirect
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7 // indirect
-	google.golang.org/genproto v0.0.0-20211115160612-a5da7257a6f7 // indirect
+	google.golang.org/genproto v0.0.0-20211117155847-120650a500bb // indirect
 	gopkg.in/ini.v1 v1.64.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/rabbitmq/amqp091-go v1.1.0 h1:qx8cGMJha71/5t31Z+LdPLdPrkj/BvD38cqC3Bi1pNI=
-github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
+github.com/rabbitmq/amqp091-go v1.2.0 h1:1pHBxAsQh54R9eX/xo679fUEAfv3loMqi0pvRFOj2nk=
+github.com/rabbitmq/amqp091-go v1.2.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -523,8 +523,8 @@ golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211115234514-b4de73f9ece8 h1:5QRxNnVsaJP6NAse0UdkRgL3zHMvCRRkrDVLNdNpdy4=
-golang.org/x/crypto v0.0.0-20211115234514-b4de73f9ece8/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -605,8 +605,9 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211116231205-47ca1ff31462 h1:2vmJlzGKvQ7e/X9XT0XydeWDxmqx8DnegiIMRT+5ssI=
+golang.org/x/net v0.0.0-20211116231205-47ca1ff31462/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -711,8 +712,8 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c h1:DHcbWVXeY+0Y8HHKR+rbLwnoh2F4tNCY7rTiHJ30RmA=
-golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 h1:kwrAHlwJ0DUBZwQ238v+Uod/3eZ8B2K5rYsUHBQvzmI=
+golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -881,8 +882,8 @@ google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67/go.mod h1:ob2IJxKr
 google.golang.org/genproto v0.0.0-20210813162853-db860fec028c/go.mod h1:cFeNkxwySK631ADgubI+/XFU/xp8FD5KIVV4rj8UC5w=
 google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211115160612-a5da7257a6f7 h1:0LoCYJF53PEqtJOntKxGD72X/c8Xto5EZ4HLrt9D80I=
-google.golang.org/genproto v0.0.0-20211115160612-a5da7257a6f7/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211117155847-120650a500bb h1:B1cc9lxfg3Zd0zoHxwyckY7YPprzkXKNWw9sxJ3/obk=
+google.golang.org/genproto v0.0.0-20211117155847-120650a500bb/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/http/middleware/static/plugin.go
+++ b/http/middleware/static/plugin.go
@@ -134,18 +134,6 @@ func (s *Plugin) Middleware(next http.Handler) http.Handler {
 			// file extension allowed
 		}
 
-		if s.cfg.Static.Request != nil {
-			for k, v := range s.cfg.Static.Request {
-				r.Header.Add(k, v)
-			}
-		}
-
-		if s.cfg.Static.Response != nil {
-			for k, v := range s.cfg.Static.Response {
-				w.Header().Set(k, v)
-			}
-		}
-
 		// ok, file is not in the forbidden list
 		// Stat it and get file info
 		f, err := s.root.Open(fPath)
@@ -186,6 +174,18 @@ func (s *Plugin) Middleware(next http.Handler) http.Handler {
 		// set etag
 		if s.cfg.Static.CalculateEtag {
 			SetEtag(s.cfg.Static.Weak, f, finfo.Name(), w)
+		}
+
+		if s.cfg.Static.Request != nil {
+			for k, v := range s.cfg.Static.Request {
+				r.Header.Add(k, v)
+			}
+		}
+
+		if s.cfg.Static.Response != nil {
+			for k, v := range s.cfg.Static.Response {
+				w.Header().Set(k, v)
+			}
 		}
 
 		// we passed all checks - serve the file

--- a/http/serve.go
+++ b/http/serve.go
@@ -179,24 +179,12 @@ func (p *Plugin) tlsAddr(host string, forcePort bool) string {
 	return host
 }
 
-// static plugin name
-const static string = "static"
-
 func applyMiddlewares(server *http.Server, middlewares map[string]Middleware, order []string, log logger.Logger) {
 	for i := len(order) - 1; i >= 0; i-- {
-		// set static last in the row
-		if order[i] == static {
-			continue
-		}
 		if mdwr, ok := middlewares[order[i]]; ok {
 			server.Handler = mdwr.Middleware(server.Handler)
 		} else {
 			log.Warn("requested middleware does not exist", "requested", order[i])
 		}
-	}
-
-	// set static if exists
-	if mdwr, ok := middlewares[static]; ok {
-		server.Handler = mdwr.Middleware(server.Handler)
 	}
 }

--- a/tests/plugins/http/configs/.rr-http-static-etags.yaml
+++ b/tests/plugins/http/configs/.rr-http-static-etags.yaml
@@ -6,7 +6,7 @@ server:
 http:
   address: 127.0.0.1:21603
   max_request_size: 1024
-  middleware: ["gzip"]
+  middleware: [ "static","gzip" ]
   trusted_subnets:
     [
       "10.0.0.0/8",

--- a/tests/plugins/http/configs/.rr-http-static-files.yaml
+++ b/tests/plugins/http/configs/.rr-http-static-files.yaml
@@ -6,7 +6,7 @@ server:
 http:
   address: 127.0.0.1:34653
   max_request_size: 1024
-  middleware: ["gzip"]
+  middleware: [ "static","gzip" ]
   trusted_subnets:
     [
       "10.0.0.0/8",

--- a/tests/plugins/http/configs/.rr-http-static-security.yaml
+++ b/tests/plugins/http/configs/.rr-http-static-security.yaml
@@ -6,17 +6,7 @@ server:
 http:
   address: 127.0.0.1:21603
   max_request_size: 1024
-  middleware: ["gzip"]
-  trusted_subnets:
-    [
-      "10.0.0.0/8",
-      "127.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16",
-      "::1/128",
-      "fc00::/7",
-      "fe80::/10",
-    ]
+  middleware: [ "static","gzip" ]
   uploads:
     forbid: [".php", ".exe", ".bat"]
   static:

--- a/tests/plugins/http/configs/.rr-http-static.yaml
+++ b/tests/plugins/http/configs/.rr-http-static.yaml
@@ -16,9 +16,9 @@ http:
     calculate_etag: true
     weak: false
     request:
-      "input": "custom-header"
+      input: "custom-header"
     response:
-      "output": "output-header"
+      output: "output-header"
   pool:
     num_workers: 2
     max_jobs: 0

--- a/tests/plugins/http/configs/.rr-http-static.yaml
+++ b/tests/plugins/http/configs/.rr-http-static.yaml
@@ -6,23 +6,13 @@ server:
 http:
   address: 127.0.0.1:21603
   max_request_size: 1024
-  middleware: ["gzip"]
-  trusted_subnets:
-    [
-      "10.0.0.0/8",
-      "127.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16",
-      "::1/128",
-      "fc00::/7",
-      "fe80::/10",
-    ]
+  middleware: [ "static","gzip" ]
   uploads:
-    forbid: [".php", ".exe", ".bat"]
+    forbid: [ ".php", ".exe", ".bat" ]
   static:
     dir: "../../../tests"
-    forbid: [""]
-    allow: [".txt", ".php"]
+    forbid: [ "" ]
+    allow: [ ".txt", ".php" ]
     calculate_etag: true
     weak: false
     request:

--- a/tests/plugins/http/http_plugin_test.go
+++ b/tests/plugins/http/http_plugin_test.go
@@ -1815,6 +1815,7 @@ func TestStaticEtagPlugin(t *testing.T) {
 
 	time.Sleep(time.Second)
 	t.Run("ServeSampleEtag", serveStaticSampleEtag)
+	t.Run("NoStaticHeaders", noStaticHeaders)
 
 	stopCh <- struct{}{}
 	wg.Wait()
@@ -1847,6 +1848,18 @@ func serveStaticSampleEtag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNotModified, resp.StatusCode)
 	_ = resp.Body.Close()
+}
+
+// regular request should not contain static headers
+func noStaticHeaders(t *testing.T) {
+	// OK 200 response
+	_, r, err := get("http://127.0.0.1:21603")
+	assert.NoError(t, err)
+	assert.NotContains(t, r.Header["input"], "custom-header")
+	assert.NotContains(t, r.Header["output"], "output-header")
+	assert.Equal(t, r.StatusCode, http.StatusOK)
+
+	_ = r.Body.Close()
 }
 
 func TestStaticPluginSecurity(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

closes: #115 

## Description of Changes

- Set request and response headers for the static files right before the serve.
- Do not reorder the middleware.

No static headers in the regular request
![image](https://user-images.githubusercontent.com/8040338/142372798-43d46516-e00b-49a3-b259-7a0098572c75.png)

```yaml
  static:
    dir: "../../../tests"
    forbid: [ "" ]
    allow: [ ".txt", ".php" ]
    calculate_etag: true
    weak: false
    request:
      input: "custom-header"
    response:
      output: "output-header"
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
