### PR TITLE
feat(server): `on_init` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,34 @@ fileserver:
     max_age: 10
     bytes_range: true
 ```
+
+- ✏️ `on_init` option for the `server` plugin. `on_init` code executed before the regular command and can be used to warm up the application for example. Failed `on_init` command doesn't affect the main command, so, the RR will continue to run.
+
+Config:
+```yaml
+# Application server settings (docs: https://roadrunner.dev/docs/php-worker)
+server:
+  on_init:
+    # Command to execute before the main server's command
+    #
+    # This option is required if using on_init
+    command: "any php or script here"
+    
+    # Script execute timeout
+    #
+    # Default: 60s [60m, 60h], if used w/o units its means - NANOSECONDS.
+    exec_timeout: 20s
+    
+    # Environment variables for the worker processes.
+    #
+    # Default: <empty map>
+    env:
+      - SOME_KEY: "SOME_VALUE"
+      - SOME_KEY2: "SOME_VALUE2" 
+
+  # ..REGULAR SERVER OPTIONS...
+```
+
 ## 🩹 Fixes:
 
 - 🐛 Fix: GRPC server will show message when started.

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/spiral/endure v1.0.8
 	github.com/spiral/errors v1.0.12
 	github.com/spiral/goridge/v3 v3.2.3
-	github.com/spiral/roadrunner/v2 v2.6.0-alpha.5
+	github.com/spiral/roadrunner/v2 v2.6.0-beta.1
 	// spiral
 	github.com/stretchr/testify v1.7.0
 	github.com/yookoala/gofast v0.6.0
@@ -68,7 +68,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/libdns/libdns v0.2.1 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/mattn/go-colorable v0.1.11 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/miekg/dns v1.1.43 // indirect

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11 h1:nQ+aFkoE2TMGc0b68U2OKSexC+eq46+XwZzWXHRmPYs=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
@@ -443,8 +445,8 @@ github.com/spiral/errors v1.0.12 h1:38Waf8ZL/Xvxg4HTYGmrUbvi7TCHivmuatNQZlBhQ8s=
 github.com/spiral/errors v1.0.12/go.mod h1:j5UReqxZxfkwXkI9mFY87VhEXcXmSg7kAk5Sswy1eEA=
 github.com/spiral/goridge/v3 v3.2.3 h1:iNz6aD/c00hC50wo+qT8uP5ZZ3VdCAERXUtNiyDE3Yo=
 github.com/spiral/goridge/v3 v3.2.3/go.mod h1:DA4Ekw9qVcTvVouUNJgxESXURBHZ2SfkliCEIpEl9lA=
-github.com/spiral/roadrunner/v2 v2.6.0-alpha.5 h1:2NxZHlUcLLteVNUU07YoJUhAqizgS7t4wI9N6SqNAtQ=
-github.com/spiral/roadrunner/v2 v2.6.0-alpha.5/go.mod h1:jIza8RZxcugpZwauQzB3sqfYylinpLZHMAcW+rcbvJE=
+github.com/spiral/roadrunner/v2 v2.6.0-beta.1 h1:KclxM//n7WRirmC/8KtBm0kbl6XDzFJB2dTKefqAjxU=
+github.com/spiral/roadrunner/v2 v2.6.0-beta.1/go.mod h1:5DtFih55yde661Z7UOSIVCrHM6MrayG104g1LTMc/V0=
 github.com/spiral/tcplisten v1.0.0 h1:dII3R20Xslll6Uk60ac1JCn9zQwfwbt88CLrs3OryZg=
 github.com/spiral/tcplisten v1.0.0/go.mod h1:+anIsZh2ZYw2EogG2pO1yEZKcGN7lEf41hUQilctYJo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -711,7 +713,6 @@ golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1 h1:kwrAHlwJ0DUBZwQ238v+Uod/3eZ8B2K5rYsUHBQvzmI=
 golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/rpc/config.go
+++ b/rpc/config.go
@@ -10,8 +10,8 @@ import (
 
 // Config defines RPC service config.
 type Config struct {
-	// Listen string
-	Listen string
+	// Listen address string
+	Listen string `mapstructure:"listen"`
 }
 
 // InitDefaults allows to init blank config with pre-defined set of default values.

--- a/server/config.go
+++ b/server/config.go
@@ -2,59 +2,78 @@ package server
 
 import (
 	"time"
+
+	"github.com/spiral/errors"
 )
 
 // Config All config (.rr.yaml)
 // For other section use pointer to distinguish between `empty` and `not present`
 type Config struct {
-	// Server config section
-	Server struct {
-		// Command to run as application.
-		Command string `mapstructure:"command"`
-		// User to run application under.
-		User string `mapstructure:"user"`
-		// Group to run application under.
-		Group string `mapstructure:"group"`
-		// Env represents application environment.
-		Env Env `mapstructure:"env"`
-		// Relay defines connection method and factory to be used to connect to workers:
-		// "pipes", "tcp://:6001", "unix://rr.sock"
-		// This config section must not change on re-configuration.
-		Relay string `mapstructure:"relay"`
-		// RelayTimeout defines for how long socket factory will be waiting for worker connection. This config section
-		// must not change on re-configuration. Defaults to 60s.
-		RelayTimeout time.Duration `mapstructure:"relay_timeout"`
-	} `mapstructure:"server"`
+	// OnInit configuration
+	OnInit *OnInitConfig `mapstructure:"on_init"`
 
-	// we just need to know if the section exist, we don't need to read config from it
-	RPC *struct {
-		Listen string `mapstructure:"listen"`
-	} `mapstructure:"rpc"`
-	Logs *struct {
-	} `mapstructure:"logs"`
-	HTTP *struct {
-	} `mapstructure:"http"`
-	Redis *struct {
-	} `mapstructure:"redis"`
-	Boltdb *struct {
-	} `mapstructure:"boltdb"`
-	Memcached *struct {
-	} `mapstructure:"memcached"`
-	Memory *struct {
-	} `mapstructure:"memory"`
-	Metrics *struct {
-	} `mapstructure:"metrics"`
-	Reload *struct {
-	} `mapstructure:"reload"`
+	// Command to run as application.
+	Command string `mapstructure:"command"`
+
+	// User to run application under.
+	User string `mapstructure:"user"`
+
+	// Group to run application under.
+	Group string `mapstructure:"group"`
+
+	// Env represents application environment.
+	Env Env `mapstructure:"env"`
+
+	// Relay defines connection method and factory to be used to connect to workers:
+	// "pipes", "tcp://:6001", "unix://rr.sock"
+	// This config section must not change on re-configuration.
+	Relay string `mapstructure:"relay"`
+
+	// RelayTimeout defines for how long socket factory will be waiting for worker connection. This config section
+	// must not change on re-configuration. Defaults to 60s.
+	RelayTimeout time.Duration `mapstructure:"relay_timeout"`
+}
+
+type OnInitConfig struct {
+	// Command which is started before worker starts
+	Command string `mapstructure:"command"`
+
+	// ExecTimeout is execute timeout for the command
+	ExecTimeout time.Duration `mapstructure:"exec_timeout"`
+
+	// Env represents application environment.
+	Env Env `mapstructure:"env"`
+}
+
+// RPCConfig should be in sync with rpc/config.go
+// Used to set RPC address env
+type RPCConfig struct {
+	Listen string `mapstructure:"listen"`
 }
 
 // InitDefaults for the server config
-func (cfg *Config) InitDefaults() {
-	if cfg.Server.Relay == "" {
-		cfg.Server.Relay = "pipes"
+func (cfg *Config) InitDefaults() error {
+	if cfg.Command == "" {
+		return errors.Str("command should not be empty")
 	}
 
-	if cfg.Server.RelayTimeout == 0 {
-		cfg.Server.RelayTimeout = time.Second * 60
+	if cfg.Relay == "" {
+		cfg.Relay = "pipes"
 	}
+
+	if cfg.RelayTimeout == 0 {
+		cfg.RelayTimeout = time.Second * 60
+	}
+
+	if cfg.OnInit != nil {
+		if cfg.OnInit.Command == "" {
+			return errors.Str("on_init command should not be empty")
+		}
+
+		if cfg.OnInit.ExecTimeout == 0 {
+			cfg.OnInit.ExecTimeout = time.Minute
+		}
+	}
+
+	return nil
 }

--- a/server/docs/server.md
+++ b/server/docs/server.md
@@ -7,6 +7,24 @@
 ```yaml
 # Application server settings (docs: https://roadrunner.dev/docs/php-worker)
 server:
+  on_init:
+    # Command to execute before the main server's command
+    #
+    # This option is required if using on_init
+    command: "any php or script here"
+    
+    # Script execute timeout
+    #
+    # Default: 60s [60m, 60h], if used w/o units its means - NANOSECONDS.
+    exec_timeout: 20s
+    
+    # Environment variables for the worker processes.
+    #
+    # Default: <empty map>
+    env:
+      - SOME_KEY: "SOME_VALUE"
+      - SOME_KEY2: "SOME_VALUE2" 
+
   # Worker starting command, with any required arguments.
   #
   # This option is required.

--- a/server/oninit.go
+++ b/server/oninit.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spiral/errors"
+	"github.com/spiral/roadrunner/v2/utils"
+)
+
+func (p *Plugin) runOnInitCommand() error {
+	const op = errors.Op("server_on_init")
+	stopCh := make(chan struct{}, 1)
+
+	cmd := p.createProcess(p.cfg.OnInit.Env, p.cfg.OnInit.Command)
+	timer := time.NewTimer(p.cfg.OnInit.ExecTimeout)
+
+	err := cmd.Start()
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	go func() {
+		errW := cmd.Wait()
+		if errW != nil {
+			p.log.Error("process wait", "error", errW)
+		}
+
+		stopCh <- struct{}{}
+	}()
+
+	select {
+	case <-timer.C:
+		err = cmd.Process.Kill()
+		if err != nil {
+			p.log.Error("process killed", "error", err)
+		}
+		return nil
+
+	case <-stopCh:
+		timer.Stop()
+		return nil
+	}
+}
+
+func (p *Plugin) Write(data []byte) (int, error) {
+	p.log.Info(utils.AsString(data))
+	return len(data), nil
+}
+
+// create command for the process
+func (p *Plugin) createProcess(env Env, cmd string) *exec.Cmd {
+	// cmdArgs contain command arguments if the command in form of: php <command> or ls <command> -i -b
+	var cmdArgs []string
+	var command *exec.Cmd
+	cmdArgs = append(cmdArgs, strings.Split(cmd, " ")...)
+	if len(cmdArgs) < 2 {
+		command = exec.Command(cmd)
+	} else {
+		command = exec.Command(cmdArgs[0], cmdArgs[1:]...) //nolint:gosec
+	}
+
+	command.Env = p.setEnv(env)
+	// redirect stderr and stdout into the Write function of the process.go
+	command.Stderr = p
+	command.Stdout = p
+
+	return command
+}

--- a/tests/loop.php
+++ b/tests/loop.php
@@ -1,0 +1,6 @@
+<?php
+for ($x = 0; $x <= 5; $x++) {
+  sleep(1);
+  error_log("The number is: $x", 0);
+}
+?>

--- a/tests/plugins/server/configs/.rr-sockets-on-init-fast-close.yaml
+++ b/tests/plugins/server/configs/.rr-sockets-on-init-fast-close.yaml
@@ -1,0 +1,15 @@
+server:
+  on_init:
+    command: "php ../../loop.php"
+    exec_timeout: 1ns
+
+  command: "php socket.php"
+  env:
+    - RR_CONFIG: "/some/place/on/the/C134"
+    - RR_CONFIG2: "C138"
+  relay: "unix://unix.sock"
+  relay_timeout: "20s"
+
+logs:
+  mode: development
+  level: info

--- a/tests/plugins/server/configs/.rr-sockets-on-init.yaml
+++ b/tests/plugins/server/configs/.rr-sockets-on-init.yaml
@@ -1,0 +1,17 @@
+server:
+  on_init:
+    command: "php ../../loop.php"
+    exec_timeout: 20s
+
+  command: "php socket.php"
+  user: ""
+  group: ""
+  env:
+    - RR_CONFIG: "/some/place/on/the/C134"
+    - RR_CONFIG2: "C138"
+  relay: "unix://unix.sock"
+  relay_timeout: "20s"
+
+logs:
+  mode: development
+  level: info

--- a/tests/plugins/server/configs/.rr-tcp-on-init.yaml
+++ b/tests/plugins/server/configs/.rr-tcp-on-init.yaml
@@ -1,0 +1,16 @@
+server:
+  on_init:
+    command: "php ../../loop.php"
+    exec_timeout: 20s
+
+  command: "php tcp-on-init.php"
+  env:
+    - RR_CONFIG: "/some/place/on/the/C134"
+    - RR_CONFIG2: "C138"
+
+  relay: "tcp://127.0.0.1:10118"
+  relay_timeout: "20s"
+
+logs:
+  mode: development
+  level: info

--- a/tests/plugins/server/configs/.rr-tcp.yaml
+++ b/tests/plugins/server/configs/.rr-tcp.yaml
@@ -1,7 +1,5 @@
 server:
   command: "php tcp.php"
-  user: ""
-  group: ""
   env:
     - RR_CONFIG: "/some/place/on/the/C134"
     - RR_CONFIG2: "C138"

--- a/tests/plugins/server/configs/.rr-wrong-command-on-init.yaml
+++ b/tests/plugins/server/configs/.rr-wrong-command-on-init.yaml
@@ -1,0 +1,11 @@
+server:
+  on_init:
+    command: "php some_file.php"
+
+  command: "php some_absent_file.php"
+  relay: "pipes"
+  relay_timeout: "20s"
+
+logs:
+  mode: development
+  level: error

--- a/tests/plugins/server/configs/.rr.yaml
+++ b/tests/plugins/server/configs/.rr.yaml
@@ -2,6 +2,7 @@ server:
   command: "php ../../client.php echo pipes"
   relay: "pipes"
   relay_timeout: "20s"
+
 logs:
   mode: development
   level: info

--- a/tests/plugins/server/plugin_pipes.go
+++ b/tests/plugins/server/plugin_pipes.go
@@ -74,6 +74,10 @@ func (f *Foo) Serve() chan error {
 		return errCh
 	}
 
+	go func() {
+		_ = w.Wait()
+	}()
+
 	// test that our worker is functional
 	sw := worker.From(w)
 

--- a/tests/plugins/server/plugin_sockets.go
+++ b/tests/plugins/server/plugin_sockets.go
@@ -55,6 +55,9 @@ func (f *Foo2) Serve() chan error {
 		return errCh
 	}
 
+	go func() {
+		_ = w.Wait()
+	}()
 	// test that our worker is functional
 	sw := worker.From(w)
 

--- a/tests/plugins/server/plugin_tcp.go
+++ b/tests/plugins/server/plugin_tcp.go
@@ -55,6 +55,10 @@ func (f *Foo3) Serve() chan error {
 		return errCh
 	}
 
+	go func() {
+		_ = w.Wait()
+	}()
+
 	// test that our worker is functional
 	sw := worker.From(w)
 

--- a/tests/plugins/server/tcp-on-init.php
+++ b/tests/plugins/server/tcp-on-init.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @var Goridge\RelayInterface $relay
+ */
+
+use Spiral\Goridge;
+use Spiral\RoadRunner;
+
+require dirname(__DIR__) . "/../vendor/autoload.php";
+
+$relay = new Goridge\SocketRelay("127.0.0.1", 10118);
+$rr = new RoadRunner\Worker($relay);
+
+while ($in = $rr->waitPayload()) {
+    try {
+        $rr->respond(new RoadRunner\Payload((string)$in->body));
+    } catch (\Throwable $e) {
+        $rr->error((string)$e);
+    }
+}


### PR DESCRIPTION
# Reason for This PR

closes: #57 

## Description of Changes

- Add a new `on_init` server configuration key.

Config:
```yaml
# Application server settings (docs: https://roadrunner.dev/docs/php-worker)
server:
  on_init:
    # Command to execute before the main server's command
    #
    # This option is required if using on_init
    command: "any php or script here"
    
    # Script execute timeout
    #
    # Default: 60s [60m, 60h], if used w/o units its means - NANOSECONDS.
    exec_timeout: 20s
    
    # Environment variables for the worker processes.
    #
    # Default: <empty map>
    env:
      - SOME_KEY: "SOME_VALUE"
      - SOME_KEY2: "SOME_VALUE2" 

  # Worker starting command, with any required arguments.
  #
  # This option is required.
  command: "php psr-worker.php"

  # Username (not UID) for the worker processes. An empty value means to use the RR process user.
  #
  # Default: ""
  user: ""

  # Group name (not GID) for the worker processes. An empty value means to use the RR process user.
  #
  # Default: ""
  group: ""

  # Environment variables for the worker processes.
  #
  # Default: <empty map>
  env:
    - SOME_KEY: "SOME_VALUE"
    - SOME_KEY2: "SOME_VALUE2"

  # Worker relay can be: "pipes", TCP (eg.: tcp://127.0.0.1:6002), or socket (eg.: unix:///var/run/rr.sock).
  #
  # Default: "pipes"
  relay: pipes

  # Timeout for relay connection establishing (only for socket and TCP port relay).
  #
  # Default: 60s
  relay_timeout: 60s
```

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
