### PR TITLE
bug(http_metrics): fix incorrect metrics type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@ Now, pipelines have only `driver` key with the configuration under the `config` 
         delete_after_ack: false
 ```
 
+## 🩹 Fixes:
+- 🐛 Fix: Wrong metrics type for the `rr_http_requests_queue`, [bug](https://github.com/spiral/roadrunner-plugins/issues/162) (@victor-sudakov)
+
 ## v2.6.4 (7.12.2021)
 
 ## 📦 Packages:

--- a/tests/plugins/metrics/metrics_test.go
+++ b/tests/plugins/metrics/metrics_test.go
@@ -1119,8 +1119,7 @@ func TestHTTPMetricsNoFreeWorkers(t *testing.T) {
 
 	genericOut, err := get2()
 	assert.NoError(t, err)
-	assert.Contains(t, genericOut, `rr_http_requests_queue_sum`)
-	assert.Contains(t, genericOut, `rr_http_requests_queue_count`)
+	assert.Contains(t, genericOut, `rr_http_requests_queue`)
 	assert.Contains(t, genericOut, `rr_http_no_free_workers_total 1`)
 
 	close(sig)


### PR DESCRIPTION
# Reason for This PR

closes: #162 

## Description of Changes

- Change `rr_http_requests_queue` type from `Summary` to `Gauge`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
